### PR TITLE
[WIP]: 77 add visit esope if comment in fortran abstract json visitor

### DIFF
--- a/src/EsopeImporter-Tests/JsonToIASTVisitorTest.class.st
+++ b/src/EsopeImporter-Tests/JsonToIASTVisitorTest.class.st
@@ -789,6 +789,35 @@ JsonToIASTVisitorTest >> testEsoSlWithTwoDot [
 	self assert: stmt entities second entities second entityName equals: 'i'.
 ]
 
+{ #category : #'tests-esope' }
+JsonToIASTVisitorTest >> testEsopeIfCommentStatement [
+"      subroutine sub()
+c@_   IF (N.GT.0) SEGINI P
+      end
+"
+	| programFile seg cond |
+	
+	self skip.
+	
+	programFile :=  self visitJsonCode: '{"meta":{"miVersion":"fortran77","miFilename":"test.f"},"program_units":[{"anno":[],"arguments":null,"blocks":[{"anno":[],"comment":"@_   IF (N.GT.0) SEGINI P","span":"(2:1)-(2:26)","tag":"comment"}],"name":"sub","options":[null,null],"span":"(1:7)-(3:9)","subprograms":null,"tag":"subroutine"}]}'.
+
+	self assert: programFile progUnits size equals: 1.
+	
+	cond := programFile progUnits first body first first.
+	self assert: cond class equals: IASTVarAccess.
+	self assert: cond entityName equals: 'n'.
+
+	seg := programFile progUnits first body first second.
+	self assert: seg class equals: IASTEsopeSegCommand.
+	self assert: seg entityName equals: 'p'.
+	self assert: seg esopeCommand equals: 'segini'.
+	self assert: seg sourceAnchor class equals: IASTIndexedFileAnchor.
+	self assert: seg sourceAnchor startLine equals: 2.
+	self assert: seg sourceAnchor startColumn equals: 19.
+	self assert: seg sourceAnchor endLine equals: 2.
+	self assert: seg sourceAnchor endColumn equals: 29
+]
+
 { #category : #'tests-statement' }
 JsonToIASTVisitorTest >> testFunctionWithFunctionInvocation [
 "      integer function efunc()

--- a/src/EsopeImporter/FortranAbstractJsonVisitor.class.st
+++ b/src/EsopeImporter/FortranAbstractJsonVisitor.class.st
@@ -119,6 +119,11 @@ FortranAbstractJsonVisitor >> processEsopeComment: anEsopeCommentNode [
 	, esopeCommand
 ]
 
+{ #category : #helpers }
+FortranAbstractJsonVisitor >> processEsopeIfComment: anEsopeIfCommentNode [ 
+	self shouldBeImplemented.
+]
+
 { #category : #'visiting expression' }
 FortranAbstractJsonVisitor >> visitAddition: anAdditionOperatorNode [
 ]
@@ -528,6 +533,11 @@ FortranAbstractJsonVisitor >> visitEsopeEndsegmentComment: anEsopeCommentNode [
 
 	^self processEsopeComment: anEsopeCommentNode
 
+]
+
+{ #category : #visiting }
+FortranAbstractJsonVisitor >> visitEsopeIfComment: anEsopeIfCommentNode [ 
+	^self processEsopeIfComment: anEsopeIfCommentNode
 ]
 
 { #category : #'visiting esope' }

--- a/src/EsopeImporter/FortranAbstractJsonVisitor.class.st
+++ b/src/EsopeImporter/FortranAbstractJsonVisitor.class.st
@@ -189,6 +189,13 @@ FortranAbstractJsonVisitor >> visitAttributes: aNode [
 	^nil
 ]
 
+{ #category : #'visiting expression' }
+FortranAbstractJsonVisitor >> visitBackspaceStatement: aBackspaceStatementNode [
+
+	^self visitJsonMap: aBackspaceStatementNode keys: #( span specification )
+
+]
+
 { #category : #'visiting statement' }
 FortranAbstractJsonVisitor >> visitBase_type: aString [
 	"to offer the possibility to handle each baseType differently, we create #visitXYZBaseType: methods"
@@ -241,6 +248,13 @@ FortranAbstractJsonVisitor >> visitCallStatement: aCallStatementNode [
 { #category : #'visiting statement' }
 FortranAbstractJsonVisitor >> visitCharacterBaseType: aString [
 	^aString
+
+]
+
+{ #category : #'visiting expression' }
+FortranAbstractJsonVisitor >> visitCloseStatement: aCloseStatementNode [
+
+	^self visitJsonMap: aCloseStatementNode keys: #( span specification )
 
 ]
 
@@ -856,6 +870,13 @@ FortranAbstractJsonVisitor >> visitInitial: anInitialNode [
 ]
 
 { #category : #'visiting expression' }
+FortranAbstractJsonVisitor >> visitInquireStatement: anInquireStatementNode [
+
+	^self visitJsonMap: anInquireStatementNode keys: #( span specification )
+
+]
+
+{ #category : #'visiting expression' }
 FortranAbstractJsonVisitor >> visitInteger: anIntegerNode [
 	"to be more explicit, Integer nodes are 'transformed' in IntegerLiteralValue nodes"
 	^self visitIntegerLiteralValue: (anIntegerNode at: 'contents')
@@ -1008,7 +1029,10 @@ FortranAbstractJsonVisitor >> visitLimit: aLimitNode [
 { #category : #visiting }
 FortranAbstractJsonVisitor >> visitList: aListNode [
 	"key 'list' used for different things should be treated upstream and never reach this point"
-	self shouldNotImplement 
+	self flag: #FIXME. "self shouldNotImplement"
+	aListNode ifNil: [ ^#() ].
+
+	^self visitJsonElement: aListNode
 ]
 
 { #category : #'visiting expression' }
@@ -1119,6 +1143,13 @@ FortranAbstractJsonVisitor >> visitOp: anOpNode [
 ]
 
 { #category : #'visiting expression' }
+FortranAbstractJsonVisitor >> visitOpenStatement: anOpenStatementNode [
+
+	^self visitJsonMap: anOpenStatementNode keys: #( span specification )
+
+]
+
+{ #category : #'visiting expression' }
 FortranAbstractJsonVisitor >> visitOr: anOrOperatorNode [
 	^ '.or.'
 ]
@@ -1213,8 +1244,22 @@ FortranAbstractJsonVisitor >> visitReturn_spec: aReturn_specNode [
 ]
 
 { #category : #'visiting expression' }
+FortranAbstractJsonVisitor >> visitRewindStatement: aRewindStatementNode [
+
+	^self visitJsonMap: aRewindStatementNode keys: #( span specification )
+
+]
+
+{ #category : #'visiting expression' }
 FortranAbstractJsonVisitor >> visitRight: aRightNode [
 	^self visitJsonElement: aRightNode
+]
+
+{ #category : #'visiting expression' }
+FortranAbstractJsonVisitor >> visitSaveStatement: aSaveStatementNode [
+
+	^self visitJsonMap: aSaveStatementNode keys: #( span vars )
+
 ]
 
 { #category : #visiting }
@@ -1254,6 +1299,13 @@ FortranAbstractJsonVisitor >> visitSpan: aSpanString [
 
 	^ {one asInteger @ two asInteger .
 		three asInteger @ (four asInteger + 1) }
+]
+
+{ #category : #'visiting expression' }
+FortranAbstractJsonVisitor >> visitSpecification: aSpecificationNode [
+
+	^self visitJsonElement: aSpecificationNode
+
 ]
 
 { #category : #visiting }

--- a/src/EsopeImporter/IASTInvocation.class.st
+++ b/src/EsopeImporter/IASTInvocation.class.st
@@ -3,7 +3,8 @@ Class {
 	#superclass : #IASTEntityRef,
 	#instVars : [
 		'isIntrinsic',
-		'arguments'
+		'arguments',
+		'indices'
 	],
 	#category : #'EsopeImporter-AST-IR'
 }
@@ -24,6 +25,18 @@ IASTInvocation >> arguments [
 IASTInvocation >> arguments: aNodes [
 
 	arguments := aNodes
+]
+
+{ #category : #accessing }
+IASTInvocation >> indices [
+
+	^ indices
+]
+
+{ #category : #accessing }
+IASTInvocation >> indices: anObject [
+
+	indices := anObject
 ]
 
 { #category : #accessing }

--- a/src/EsopeImporter/JsonToIASTVisitor.class.st
+++ b/src/EsopeImporter/JsonToIASTVisitor.class.st
@@ -107,7 +107,7 @@ JsonToIASTVisitor >> visitAssign_expression: anAssignExpressionNode [
 	"Fix assignement like this ptr.attr ... = ...."
 	data second isCollection
 		ifTrue:  [ data second allButFirst do: [ :each | each isWrite: true  ] ]
-		ifFalse: [ data second isWrite: true ].
+		ifFalse: [ data second class = IASTInvocation ifFalse: [ data second isWrite: true ] ].
 
 	^(data third isCollection 
 		ifTrue:  [ { data second } , data third ]


### PR DESCRIPTION
#78 

---

#77 : Maybe it's easier to let the parser do the if-logical and just transform the single statement.

For example: `if (condition) statement`, transform statement if it's a segxxx type esope statement.