### PR TITLE
avoid name collusion between famix and fast parsing.

### DIFF
--- a/src/EsopeImporter/FortranProjectImporter.class.st
+++ b/src/EsopeImporter/FortranProjectImporter.class.st
@@ -84,8 +84,8 @@ FortranProjectImporter class >> isDummySubroutine: aName [
 FortranProjectImporter class >> parseString: fortranCode [
 
 	| srcFile destFile |
-	srcFile  := './srcCode.f' asFileReference ensureDelete.
-	destFile := './srcCode.json' asFileReference ensureDelete.
+	srcFile  := './srcCodeOrigin.f' asFileReference ensureDelete.
+	destFile := './srcCodeOrigin.json' asFileReference ensureDelete.
 
 	srcFile writeStreamDo: [ :stream | 
 		stream << fortranCode withUnixLineEndings ].


### PR DESCRIPTION
using the same temporary name cause a collusion