### PR TITLE
Pure fortran

### DIFF
--- a/src/EsopeImporter/FortranProjectImporter.class.st
+++ b/src/EsopeImporter/FortranProjectImporter.class.st
@@ -72,7 +72,9 @@ Class {
 		'resolver',
 		'withSanityChecks',
 		'includeFolder',
-		'srcFolder'
+		'srcFolder',
+		'withEsope',
+		'fortranVersion'
 	],
 	#category : 'EsopeImporter-Importer',
 	#package : 'EsopeImporter',
@@ -254,6 +256,8 @@ FortranProjectImporter >> errors [
 FortranProjectImporter >> esopeToFortran [
 	"'de-esopifying Esope files to be able to parse them in Fortran
 	The result goes in the FortranWorkingDirectory"
+
+	withEsope ifFalse: [ ^self ].
 
 	(self collectFilesIn: self tempEsopeFolder) do: [ :path |
 		self
@@ -474,7 +478,10 @@ FortranProjectImporter >> initialize [
 
 	super initialize.
 
-	errorHandler := FortranErrorManager new
+	withEsope := true.
+
+	errorHandler := FortranErrorManager new.
+	errorHandler stopOnError: self stopOnError.
 
 ]
 

--- a/src/EsopeImporter/FortranProjectImporter.class.st
+++ b/src/EsopeImporter/FortranProjectImporter.class.st
@@ -91,7 +91,7 @@ FortranProjectImporter class >> extensionsEsope [
 { #category : 'constants' }
 FortranProjectImporter class >> extensionsFortran [
 
-	^#(f for)
+	^#(f for F90)
 ]
 
 { #category : 'importing' }
@@ -226,6 +226,13 @@ FortranProjectImporter >> defaultFileEncoding: aString [
 	defaultFileEncoding := aString
 ]
 
+{ #category : 'accessing' }
+FortranProjectImporter >> defaultFortranVersion [
+	"known Fortran versions: Fortran[66/77/77Legacy/77Extended/90/2003]
+	 66 77 77l 77e 90 2003"
+	^'77l'
+]
+
 { #category : 'private - files' }
 FortranProjectImporter >> ensureEmptyFolder: folder [
 
@@ -277,7 +284,7 @@ FortranProjectImporter >> esopeToFortran [
 { #category : 'accessing' }
 FortranProjectImporter >> f77parser [
 
-	^ 'fortran-src-extras serialize -t json -v90 encode '
+	^ 'fortran-src-extras serialize -t json -v' , self fortranVersion , ' encode '
 ]
 
 { #category : 'private - import' }
@@ -336,6 +343,19 @@ FortranProjectImporter >> fortranToJsonAST [
 		"projectPath asFileReference
 			copyTo: (self appendPath: localPath toParent: tempFortranFolder / 'src')."
 		self parseFortran77: projectPath from: srcFolder to: self tempJsonFolder / 'src' ]
+]
+
+{ #category : 'accessing' }
+FortranProjectImporter >> fortranVersion [
+
+	^fortranVersion ifNil: [ self defaultFortranVersion ]
+]
+
+{ #category : 'accessing' }
+FortranProjectImporter >> fortranVersion: version [
+	(#('66' '77' '77l' '77e' '90' '2003') includes: version)
+		ifFalse: [ Error signal: 'Unknown Fortran version: ' , version , ' choose one of 66 77 77l 77e 90 2003' ].
+	fortranVersion := version
 ]
 
 { #category : 'private - files' }


### PR DESCRIPTION
Adding options :
- `withEsope`, `noEsope` allowing to run without Esope (default is withEsope)
- indicate `fortranVersion` to the parser